### PR TITLE
Added code analysis and code coverage to the solution

### DIFF
--- a/dev-environment/roles/dev/tasks/main.yml
+++ b/dev-environment/roles/dev/tasks/main.yml
@@ -36,3 +36,13 @@
     name: devtoolset-6
     state: present
   become: true
+
+- name: Install static analysis tools
+  yum:
+    name: "{{ packages }}"
+    state: present
+  become: true
+  vars:
+    packages:
+    - cppcheck
+    - lcov

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required (VERSION 2.8.8)
 
+
 # ----------- GET TEST DEPENDENCIES -------------
 
 # Get google test dependencies
@@ -28,6 +29,11 @@ execute_process(COMMAND "${CMAKE_COMMAND}" --build .
 
 add_subdirectory("${CMAKE_BINARY_DIR}/spdlog-src"
                  "${CMAKE_BINARY_DIR}/spdlog-build")
+
+# --------- configure code coverage
+set (CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0") # debug, no optimisation
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage") # enabling coverage
 
 # --------- MAIN APPLICATION -----------
 project (GridftpACLPlugin)

--- a/src/run-code-analysis.sh
+++ b/src/run-code-analysis.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cppcheck --enable=all ./main.cpp ./framework 2>"build/cppcheck_result.txt"

--- a/src/run-code-coverage.sh
+++ b/src/run-code-coverage.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cd build
+lcov --directory . --zerocounters
+
+# build the tests and then run them
+ninja
+./test/testPlugin
+
+# process the reports
+lcov --directory . --capture --output-file coverage.info
+lcov --remove coverage.info '/opt/rh/devtoolset-6/root/usr/include/c++/*' \
+                            '/home/vagrant/src/build/googletest-src/googletest/include/gtest/*' \
+                            --output-file coverage.info
+lcov --list coverage.info
+
+genhtml --output-directory coveragereportall --legend --show-details --branch-coverage coverage.info 


### PR DESCRIPTION
I've added scripts to allow static code analysis and code coverage to be run more easily.

To test:
- build the code
- run the code analysis script and see some violations that are output (these will be fixed as we add more structure to the code).
- run the code coverage and view the report (this only reports on tests at the moment as it's not hooked up to the main code.