### PR TITLE
Feature/write a plugin that logs #4

### DIFF
--- a/demo-scripts/sprint2/ftpClient.py
+++ b/demo-scripts/sprint2/ftpClient.py
@@ -20,7 +20,7 @@ print('Send command to print working dir to gridFTP server...')
 print('Server returned: ')
 print('\t' + ftp.sendcmd('PWD'))
 
-print('\t' + ftp.sendcmd('SITE USAGE test'))
+print('\t' + ftp.sendcmd('SITE GETPERMISSIONS test'))
 
 # Send a custom registered command
 #ftp.sendcmd('SITE', args)

--- a/demo-scripts/sprint2/ftpClient.py
+++ b/demo-scripts/sprint2/ftpClient.py
@@ -11,6 +11,7 @@ host = 'localhost'
 port = 5000
 
 ftp = FTP()
+ftp.set_debuglevel(2)
 ftp.connect(host, port)
 ftp.login()
 
@@ -18,6 +19,8 @@ ftp.login()
 print('Send command to print working dir to gridFTP server...')
 print('Server returned: ')
 print('\t' + ftp.sendcmd('PWD'))
+
+print('\t' + ftp.sendcmd('SITE USAGE test'))
 
 # Send a custom registered command
 #ftp.sendcmd('SITE', args)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,9 @@ add_executable (GridftpACLPlugin main.cpp ${framework_src})
 target_link_libraries (GridftpACLPlugin spdlog)
 target_link_libraries (globus_gridftp_server_permissions_plugin spdlog)
 
+set_target_properties (globus_gridftp_server_permissions_plugin PROPERTIES
+  LINK_FLAGS "${GLOBUS_FTPLIB}")
+
 install (TARGETS GridftpACLPlugin DESTINATION bin)
 
 

--- a/src/permissions_plugin.cpp
+++ b/src/permissions_plugin.cpp
@@ -1,299 +1,369 @@
-/*
- * Copyright 1999-2006 University of Chicago
- * 
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- * http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+#include <stdio.h>
+#include <iostream>
 
-#include "globus_gridftp_server.h"
-
-/*@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
- *  ADD ADDITIONAL INCLUDES HERE
- *@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@*/
-
-static
-globus_version_t local_version =
+extern "C"
 {
+  // IMPORTANT: the gridftp code must be inside the extern C brackets so the names are preserved  
+  #include "globus_gridftp_server.h"
+
+  static
+  globus_version_t local_version =
+  {
     0, /* major version number */
     1, /* minor version number */
     0,
     0 /* branch ID */
-};
+  };
 
-typedef struct globus_l_gfs_permissions_plugin_handle_s
-{
+  typedef struct globus_l_gfs_permissions_plugin_handle_s
+  {
     int                                 some_needed_data;
-} globus_l_gfs_permissions_plugin_handle_t;
+  } globus_l_gfs_permissions_plugin_handle_t;
 
-/*************************************************************************
- *  start
- *  -----
- *  This function is called when a new session is initialized, ie a user 
- *  connectes to the server.  This hook gives the dsi an oppertunity to
- *  set internal state that will be threaded through to all other
- *  function calls associated with this session.  And an oppertunity to
- *  reject the user.
- *
- *  finished_info.info.session.session_arg should be set to an DSI
- *  defined data structure.  This pointer will be passed as the void *
- *  user_arg parameter to all other interface functions.
- * 
- *  NOTE: at nice wrapper function should exist that hides the details 
- *        of the finished_info structure, but it currently does not.  
- *        The DSI developer should jsut follow this template for now
- ************************************************************************/
-static
-void
-globus_l_gfs_permissions_plugin_start(
-    globus_gfs_operation_t              op,
-    globus_gfs_session_info_t *         session_info)
-{
-    globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
-    globus_gfs_finished_info_t          finished_info;
-    GlobusGFSName(globus_l_gfs_permissions_plugin_start);
 
-    permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *)
-        globus_malloc(sizeof(globus_l_gfs_permissions_plugin_handle_t));
+  // Most functions will be populated from the underlying 'file' DSI
+  static globus_gfs_storage_iface_t osg_dsi_iface;
 
-    permissions_plugin_handle->some_needed_data = 0;
+  static globus_extension_handle_t osg_dsi_handle = NULL;
 
-    memset(&finished_info, '\0', sizeof(globus_gfs_finished_info_t));
-    finished_info.type = GLOBUS_GFS_OP_SESSION_START;
-    finished_info.result = GLOBUS_SUCCESS;
-    finished_info.info.session.session_arg = permissions_plugin_handle;
-    finished_info.info.session.username = session_info->username;
-    finished_info.info.session.home_dir = (char *)"/";
+  static globus_gfs_storage_command_t original_command_function = NULL;
+  static globus_gfs_storage_init_t original_init_function = NULL;
 
-    globus_gridftp_server_operation_finished(
-        op, GLOBUS_SUCCESS, &finished_info);
-}
+  enum {
+    GLOBUS_GFS_OSG_CMD_SITE_USAGE = GLOBUS_GFS_MIN_CUSTOM_CMD,
+  };
 
-/*************************************************************************
- *  destroy
- *  -------
- *  This is called when a session ends, ie client quits or disconnects.
- *  The dsi should clean up all memory they associated wit the session
- *  here. 
- ************************************************************************/
-static
-void
-globus_l_gfs_permissions_plugin_destroy(
-    void *                              user_arg)
-{
-    globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
 
-    permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
+  /*************************************************************************
+   *  start
+   *  -----
+   *  This function is called when a new session is initialized, ie a user 
+   *  connectes to the server.  This hook gives the dsi an oppertunity to
+   *  set internal state that will be threaded through to all other
+   *  function calls associated with this session.  And an oppertunity to
+   *  reject the user.
+   *
+   *  finished_info.info.session.session_arg should be set to an DSI
+   *  defined data structure.  This pointer will be passed as the void *
+   *  user_arg parameter to all other interface functions.
+   * 
+   *  NOTE: at nice wrapper function should exist that hides the details 
+   *        of the finished_info structure, but it currently does not.  
+   *        The DSI developer should jsut follow this template for now
+   ************************************************************************/
+  static
+  void
+  globus_l_gfs_permissions_plugin_start(
+      globus_gfs_operation_t              op,
+      globus_gfs_session_info_t *         session_info)
+  {
+      // globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
+      // globus_gfs_finished_info_t          finished_info;
+      GlobusGFSName(globus_l_gfs_permissions_plugin_start);
 
-    globus_free(permissions_plugin_handle);
-}
+      std::cout << "starting session\n";
+      std::cout << GLOBUS_GFS_OSG_CMD_SITE_USAGE << "\n";
 
-/*************************************************************************
- *  stat
- *  ----
- *  This interface function is called whenever the server needs 
- *  information about a given file or resource.  It is called then an
- *  LIST is sent by the client, when the server needs to verify that 
- *  a file exists and has the proper permissions, etc.
- ************************************************************************/
-static
-void
-globus_l_gfs_permissions_plugin_stat(
-    globus_gfs_operation_t              op,
-    globus_gfs_stat_info_t *            stat_info,
-    void *                              user_arg)
-{
-    globus_gfs_stat_t                   stat_array[1];
-    int                                 stat_count = 1;
-    globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
-    GlobusGFSName(globus_l_gfs_permissions_plugin_stat);
+      globus_result_t result = globus_gridftp_server_add_command(op, "SITE USAGE",
+                                  GLOBUS_GFS_OSG_CMD_SITE_USAGE,
+                                  3,
+                                  5,
+                                  "SITE USAGE <sp> [TOKEN <sp> $name] <sp> $location: Get usage information for a location.",
+                                  GLOBUS_TRUE,
+                                  GFS_ACL_ACTION_LOOKUP);
 
-    permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
+      std::cout << "registered command\n";
+      if (result != GLOBUS_SUCCESS)
+      {
+          std::cout << "Failed to add custom 'SITE USAGE' command\n";
+          globus_gridftp_server_finished_session_start(op,
+                                                  result,
+                                                  NULL,
+                                                  NULL,
+                                                  NULL);
+          return;
+      }
 
-    stat_array[0].mode = 0;
-    stat_array[0].nlink = 0;
-    stat_array[0].uid = 0;
-    stat_array[0].gid = 0;
-    stat_array[0].size = 0;
-    stat_array[0].mtime = 0;
-    stat_array[0].atime = 0;
-    stat_array[0].ctime = 0;
-    stat_array[0].dev = 0;
-    stat_array[0].ino = 0;
+      std::cout << "passing through to original start function\n";
 
-    globus_gridftp_server_finished_stat(
-        op, GLOBUS_SUCCESS, stat_array, stat_count);
-}
+      original_init_function(op, session_info);
+  }
 
-/*************************************************************************
- *  command
- *  -------
- *  This interface function is called when the client sends a 'command'.
- *  commands are such things as mkdir, remdir, delete.  The complete
- *  enumeration is below.
- *
- *  To determine which command is being requested look at:
- *      cmd_info->command
- *
- *      GLOBUS_GFS_CMD_MKD = 1,
- *      GLOBUS_GFS_CMD_RMD,
- *      GLOBUS_GFS_CMD_DELE,
- *      GLOBUS_GFS_CMD_RNTO,
- *      GLOBUS_GFS_CMD_RNFR,
- *      GLOBUS_GFS_CMD_CKSM,
- *      GLOBUS_GFS_CMD_SITE_CHMOD,
- *      GLOBUS_GFS_CMD_SITE_DSI
- ************************************************************************/
-static
-void
-globus_l_gfs_permissions_plugin_command(
-    globus_gfs_operation_t              op,
-    globus_gfs_command_info_t *         cmd_info,
-    void *                              user_arg)
-{
-    globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
-    GlobusGFSName(globus_l_gfs_permissions_plugin_command);
+  /*************************************************************************
+   *  destroy
+   *  -------
+   *  This is called when a session ends, ie client quits or disconnects.
+   *  The dsi should clean up all memory they associated wit the session
+   *  here. 
+   ************************************************************************/
+  static
+  void
+  globus_l_gfs_permissions_plugin_destroy(
+      void *                              user_arg)
+  {
+      globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
 
-    permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
+      permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
 
-    globus_gridftp_server_finished_command(op, GLOBUS_SUCCESS, GLOBUS_NULL);
-}
+      globus_free(permissions_plugin_handle);
+  }
 
-/*************************************************************************
- *  recv
- *  ----
- *  This interface function is called when the client requests that a
- *  file be transfered to the server.
- *
- *  To receive a file the following functions will be used in roughly
- *  the presented order.  They are doced in more detail with the
- *  gridftp server documentation.
- *
- *      globus_gridftp_server_begin_transfer();
- *      globus_gridftp_server_register_read();
- *      globus_gridftp_server_finished_transfer();
- *
- ************************************************************************/
-static
-void
-globus_l_gfs_permissions_plugin_recv(
-    globus_gfs_operation_t              op,
-    globus_gfs_transfer_info_t *        transfer_info,
-    void *                              user_arg)
-{
-    globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
-    GlobusGFSName(globus_l_gfs_permissions_plugin_recv);
+  /*************************************************************************
+   *  stat
+   *  ----
+   *  This interface function is called whenever the server needs 
+   *  information about a given file or resource.  It is called then an
+   *  LIST is sent by the client, when the server needs to verify that 
+   *  a file exists and has the proper permissions, etc.
+   ************************************************************************/
+  static
+  void
+  globus_l_gfs_permissions_plugin_stat(
+      globus_gfs_operation_t              op,
+      globus_gfs_stat_info_t *            stat_info,
+      void *                              user_arg)
+  {
+      globus_gfs_stat_t                   stat_array[1];
+      int                                 stat_count = 1;
+      globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
+      GlobusGFSName(globus_l_gfs_permissions_plugin_stat);
 
-    permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
+      permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
 
-    globus_gridftp_server_finished_transfer(op, GLOBUS_SUCCESS);
-}
+      stat_array[0].mode = 0;
+      stat_array[0].nlink = 0;
+      stat_array[0].uid = 0;
+      stat_array[0].gid = 0;
+      stat_array[0].size = 0;
+      stat_array[0].mtime = 0;
+      stat_array[0].atime = 0;
+      stat_array[0].ctime = 0;
+      stat_array[0].dev = 0;
+      stat_array[0].ino = 0;
 
-/*************************************************************************
- *  send
- *  ----
- *  This interface function is called when the client requests to receive
- *  a file from the server.
- *
- *  To send a file to the client the following functions will be used in roughly
- *  the presented order.  They are doced in more detail with the
- *  gridftp server documentation.
- *
- *      globus_gridftp_server_begin_transfer();
- *      globus_gridftp_server_register_write();
- *      globus_gridftp_server_finished_transfer();
- *
- ************************************************************************/
-static
-void
-globus_l_gfs_permissions_plugin_send(
-    globus_gfs_operation_t              op,
-    globus_gfs_transfer_info_t *        transfer_info,
-    void *                              user_arg)
-{
-    globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
-    GlobusGFSName(globus_l_gfs_permissions_plugin_send);
+      std::cout << "Calling stat command\n";
 
-    permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
+      globus_gridftp_server_finished_stat(
+          op, GLOBUS_SUCCESS, stat_array, stat_count);
+  }
 
-    globus_gridftp_server_finished_transfer(op, GLOBUS_SUCCESS);
-}
+  /*************************************************************************
+   *  command
+   *  -------
+   *  This interface function is called when the client sends a 'command'.
+   *  commands are such things as mkdir, remdir, delete.  The complete
+   *  enumeration is below.
+   *
+   *  To determine which command is being requested look at:
+   *      cmd_info->command
+   *
+   *      GLOBUS_GFS_CMD_MKD = 1,
+   *      GLOBUS_GFS_CMD_RMD,
+   *      GLOBUS_GFS_CMD_DELE,
+   *      GLOBUS_GFS_CMD_RNTO,
+   *      GLOBUS_GFS_CMD_RNFR,
+   *      GLOBUS_GFS_CMD_CKSM,
+   *      GLOBUS_GFS_CMD_SITE_CHMOD,
+   *      GLOBUS_GFS_CMD_SITE_DSI
+   ************************************************************************/
+  static
+  void
+  globus_l_gfs_permissions_plugin_command(
+      globus_gfs_operation_t              op,
+      globus_gfs_command_info_t *         cmd_info,
+      void *                              user_arg)
+  {
+      std::cout << "Calling command function\n";
 
-static
-int
-globus_l_gfs_permissions_plugin_activate(void);
+      switch (cmd_info->command)
+      {
+      case GLOBUS_GFS_OSG_CMD_SITE_USAGE:
+          std::cout << "Calling SITE USAGE\n";
+          globus_result_t result;
+          result = GLOBUS_SUCCESS;
+          globus_gridftp_server_finished_command(op, result, (char*)"250 SITE USAGE command called successfully.\r\n");
+          return;
+      default:
+          // Anything not explicitly OSG-centric is passed to the
+          // underlying module.
+          break;
+      }
 
-static
-int
-globus_l_gfs_permissions_plugin_deactivate(void);
+      original_command_function(op, cmd_info, user_arg);
+  }
 
-/*
- *  no need to change this
- */
-static globus_gfs_storage_iface_t       globus_l_gfs_permissions_plugin_dsi_iface = 
-{
-    GLOBUS_GFS_DSI_DESCRIPTOR_BLOCKING | GLOBUS_GFS_DSI_DESCRIPTOR_SENDER,
-    globus_l_gfs_permissions_plugin_start,
-    globus_l_gfs_permissions_plugin_destroy,
-    NULL, /* list */
-    NULL, //globus_l_gfs_permissions_plugin_send,
-    NULL, //globus_l_gfs_permissions_plugin_recv,
-    NULL, /* trev */
-    NULL, /* active */
-    NULL, /* passive */
-    NULL, /* data destroy */
-    globus_l_gfs_permissions_plugin_command, 
-    NULL, //globus_l_gfs_permissions_plugin_stat,
-    NULL,
-    NULL
-};
+  /*************************************************************************
+   *  recv
+   *  ----
+   *  This interface function is called when the client requests that a
+   *  file be transfered to the server.
+   *
+   *  To receive a file the following functions will be used in roughly
+   *  the presented order.  They are doced in more detail with the
+   *  gridftp server documentation.
+   *
+   *      globus_gridftp_server_begin_transfer();
+   *      globus_gridftp_server_register_read();
+   *      globus_gridftp_server_finished_transfer();
+   *
+   ************************************************************************/
+  static
+  void
+  globus_l_gfs_permissions_plugin_recv(
+      globus_gfs_operation_t              op,
+      globus_gfs_transfer_info_t *        transfer_info,
+      void *                              user_arg)
+  {
+      std::cout << "Calling recv function\n";
 
-/*
- *  no need to change this
- */
-GlobusExtensionDefineModule(globus_gridftp_server_permissions_plugin) =
-{
-    (char *)"globus_gridftp_server_permissions_plugin",
-    globus_l_gfs_permissions_plugin_activate,
-    globus_l_gfs_permissions_plugin_deactivate,
-    NULL,
-    NULL,
-    &local_version
-};
+      globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
+      GlobusGFSName(globus_l_gfs_permissions_plugin_recv);
 
-/*
- *  no need to change this
- */
-static
-int
-globus_l_gfs_permissions_plugin_activate(void)
-{
-    globus_extension_registry_add(
-        GLOBUS_GFS_DSI_REGISTRY,
-        (char *)"permissions_plugin",
-        GlobusExtensionMyModule(globus_gridftp_server_permissions_plugin),
-        &globus_l_gfs_permissions_plugin_dsi_iface);
-    
-    return 0;
-}
+      permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
 
-/*
- *  no need to change this
- */
-static
-int
-globus_l_gfs_permissions_plugin_deactivate(void)
-{
-    globus_extension_registry_remove(
-        GLOBUS_GFS_DSI_REGISTRY, (char *)"permissions_plugin");
+      globus_gridftp_server_finished_transfer(op, GLOBUS_SUCCESS);
+  }
 
-    return 0;
+  /*************************************************************************
+   *  send
+   *  ----
+   *  This interface function is called when the client requests to receive
+   *  a file from the server.
+   *
+   *  To send a file to the client the following functions will be used in roughly
+   *  the presented order.  They are doced in more detail with the
+   *  gridftp server documentation.
+   *
+   *      globus_gridftp_server_begin_transfer();
+   *      globus_gridftp_server_register_write();
+   *      globus_gridftp_server_finished_transfer();
+   *
+   ************************************************************************/
+  static
+  void
+  globus_l_gfs_permissions_plugin_send(
+      globus_gfs_operation_t              op,
+      globus_gfs_transfer_info_t *        transfer_info,
+      void *                              user_arg)
+  {
+      std::cout << "Calling send function\n";
+      globus_l_gfs_permissions_plugin_handle_t *       permissions_plugin_handle;
+      GlobusGFSName(globus_l_gfs_permissions_plugin_send);
+
+      permissions_plugin_handle = (globus_l_gfs_permissions_plugin_handle_t *) user_arg;
+
+      globus_gridftp_server_finished_transfer(op, GLOBUS_SUCCESS);
+  }
+
+  static
+  int
+  globus_l_gfs_permissions_plugin_activate(void);
+
+  static
+  int
+  globus_l_gfs_permissions_plugin_deactivate(void);
+
+  /*
+  *  no need to change this
+  */
+  static globus_gfs_storage_iface_t       globus_l_gfs_permissions_plugin_dsi_iface = 
+  {
+      GLOBUS_GFS_DSI_DESCRIPTOR_BLOCKING | GLOBUS_GFS_DSI_DESCRIPTOR_SENDER,
+      globus_l_gfs_permissions_plugin_start,
+      globus_l_gfs_permissions_plugin_destroy,
+      NULL, /* list */
+      NULL, //globus_l_gfs_permissions_plugin_send,
+      NULL, //globus_l_gfs_permissions_plugin_recv,
+      NULL, /* trev */
+      NULL, /* active */
+      NULL, /* passive */
+      NULL, /* data destroy */
+      globus_l_gfs_permissions_plugin_command, 
+      NULL, //globus_l_gfs_permissions_plugin_stat,
+      NULL,
+      NULL
+  };
+
+  /*
+  *  no need to change this
+  */
+  GlobusExtensionDefineModule(globus_gridftp_server_permissions_plugin) =
+  {
+      (char *)"globus_gridftp_server_permissions_plugin",
+      globus_l_gfs_permissions_plugin_activate,
+      globus_l_gfs_permissions_plugin_deactivate,
+      NULL,
+      NULL,
+      &local_version
+  };
+
+  /*
+  *  no need to change this
+  */
+  static
+  int
+  globus_l_gfs_permissions_plugin_activate(void)
+  {
+      std::cout << "Activating plugin\n";
+      globus_result_t result = GLOBUS_SUCCESS;
+      memset(&osg_dsi_iface, '\0', sizeof(globus_gfs_storage_iface_t));
+      char * dsi_name = getenv("OSG_EXTENSIONS_OVERRIDE_DSI");
+      dsi_name = dsi_name ? dsi_name : (char*)"file";
+
+      std::cout << "looking up file plugin\n";
+      void *new_dsi = (globus_gfs_storage_iface_t *) globus_extension_lookup(
+          &osg_dsi_handle, GLOBUS_GFS_DSI_REGISTRY, dsi_name);
+
+      std::cout << (new_dsi == NULL ? "true" : "false");
+      if (new_dsi == NULL)
+      {
+          // char module_name[1024];
+          // snprintf(module_name, 1024, "globus_gridftp_server_%s", dsi_name);
+          // module_name[1023] = '\0';
+          std::cout << "Trying to activate file dsi\n";
+          result = globus_extension_activate("globus_gridftp_server_file");
+          if (result != GLOBUS_SUCCESS)
+          {
+              std::cout << "Unable to activate file dsi\n";
+          }
+      }
+      new_dsi = (globus_gfs_storage_iface_t *) globus_extension_lookup(
+          &osg_dsi_handle, GLOBUS_GFS_DSI_REGISTRY, dsi_name);
+
+      std::cout << (new_dsi == NULL ? "true" : "false");
+      std::cout << "copying file storage interface\n";
+      std::cout << "next step\n";
+      memcpy(&osg_dsi_iface, new_dsi, sizeof(globus_gfs_storage_iface_t));
+
+      std::cout << "assigning original commands\n";
+      original_command_function = osg_dsi_iface.command_func;
+      original_init_function = osg_dsi_iface.init_func;
+      osg_dsi_iface.command_func = globus_l_gfs_permissions_plugin_command;
+      osg_dsi_iface.init_func = globus_l_gfs_permissions_plugin_start;
+
+
+      globus_extension_registry_add(
+          GLOBUS_GFS_DSI_REGISTRY,
+          (char *)"permissions_plugin",
+          GlobusExtensionMyModule(globus_gridftp_server_permissions_plugin),
+          &osg_dsi_iface);
+
+      return 0;
+  }
+
+  /*
+  *  no need to change this
+  */
+  static
+  int
+  globus_l_gfs_permissions_plugin_deactivate(void)
+  {
+      globus_extension_registry_remove(
+          GLOBUS_GFS_DSI_REGISTRY, (char *)"permissions_plugin");
+
+      globus_extension_release(osg_dsi_handle);
+
+      return 0;
+  }
+
 }

--- a/src/run-gridftp-server.sh
+++ b/src/run-gridftp-server.sh
@@ -1,0 +1,6 @@
+LD_LIBRARY_PATH="$(pwd)"
+export LD_LIBRARY_PATH
+
+echo $LD_LIBRARY_PATH
+
+globus-gridftp-server -control-interface 127.0.0.1 -aa -p 5000 -dsi permissions_plugin -d ALL -debug


### PR DESCRIPTION
Got a plugin working and now log when the command `SITE GETPERMISSIONS` is called.

Conor, you'll want to use this as a basis for your permissions work going forward.

Steps to test:
1. Build the code
1. From the `build` folder run `../run-gridftp-server.sh` to start the server.
1. Run the ftpClient script to test calling the `SITE GETPERMISSIONS` command
1. Stop the gridftp server
1. Look at the logs in `/usr/tmp/gridftp_acl_plugin.log`