### PR TITLE
Feature/set file permissions #6

### DIFF
--- a/demos/sprint2/6-set-file-permissions.md
+++ b/demos/sprint2/6-set-file-permissions.md
@@ -1,0 +1,22 @@
+# Documentation for the gridftp plugin
+
+## Stories covered:
+
+#6 - Set the file permissions using gridFTP plugin
+
+## Demo
+1. Preconditions- vagrant machine is up to date with issue #6, dev enviornment is enabled ("scl enable devtoolset-6 bash")
+1. Create a temporary file and directory in your home folder ("mkdir /home/vagrant/TestDir/test.txt")
+1. Change the permissions to read, write and execute for all ("chmod 777 /home/vagrant/TestDir/test.txt")
+1. Run "ls -l /home/vagrant/TestDir/test.txt" to verify the permissions and ownership
+1. Start up the gridFTP server (from build directory run "../run-gridftp-server.sh")
+1. Start a python3.6 session and run the following commands:
+
+from ftplib import FTP
+ftp =FTP()
+ftp.set_debuglevel(2)
+ftp.connect('127.0.0.1', 5000)
+ftp.login()
+ftp.sendcmd('SITE SETPERMISSIONS /home/vagrant/TestDir/test.txt mode=33188;groupID=1234;userID=1234')
+
+1. Stop the server and run "ls -lt" on the file to verify the changes have taken place

--- a/src/application/FileInfoProvider.cpp
+++ b/src/application/FileInfoProvider.cpp
@@ -4,6 +4,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <sstream>
+#include <regex>
+#include <string>
 
 struct stat FileInfoProvider::GetPermissions(std::string fileLocation) const
 {
@@ -23,8 +26,7 @@ void FileInfoProvider::SetMode(std::string fileLocation, int mode) const
     cout << "setting file permissions" << "\n";
     cout << "File is: " << fileLocation << "\n";
     cout << "Mode is: " << mode << "\n";
-    int status;
-    // struct stat buffer;
+    // int status;
     // int chmod(const char *path, mode_t mode);
     // chmod((char*)"/tmp/test.txt", 100777);
     // chmod((char*)"/tmp/test.txt", S_IRWXU);
@@ -32,7 +34,6 @@ void FileInfoProvider::SetMode(std::string fileLocation, int mode) const
     chmod((char*)"/tmp/test.txt", mode);
     chmod((char*)"/home/vagrant/TestDir/test.txt", mode);
     // status = stat((char*)"/tmp/test.txt", &buffer);
-    // cout << "Mode set to: " << buffer.st_mode << endl;
 
 }
 
@@ -40,23 +41,8 @@ void FileInfoProvider::SetUserAndGroupID(std::string fileLocation, int userID, i
 {
     cout << "changing ownership and group of test file" << endl;
     cout << "uid before: " << getuid << endl;
-    //setuid(0);
-    //cout << setuid(0);
-    //cout << "uid after: " << getuid << endl;
-
     cout << userID << " and group: " << groupID << endl;
-    //THIS IS THE BIT YOU NEED!
-    chown((char*)"/tmp/test.txt", 1234, 1234);
-    
-    // cout << "Tmp dir: " << chown((char*)"/tmp/test.txt", 1234, 1234);
-    // struct stat buf;
-    // stat((char*)"/home/vagrant/src/test.txt", &buf);
-    // cout << buf.st_gid << endl;
-    // cout << buf.st_uid << endl;
-    // cout << chown((char*)"/home/vagrant/src/test.txt", 1234, 1234) << endl;
-    // cout << 
-    // system("echo vagrant | sudo chown 1234:1234 /home/vagrant/TestDir/test.txt");
-    // stat((char*)"/home/vagrant/TestDir/test.txt", &buf);
-    // cout << buf.st_gid << endl;
-    // cout << buf.st_uid << endl;
+    char * tab2 = new char [fileLocation.length()+1];
+    strcpy (tab2, fileLocation.c_str());
+    chown((char*)tab2, userID, groupID);
 }

--- a/src/application/FileInfoProvider.cpp
+++ b/src/application/FileInfoProvider.cpp
@@ -1,12 +1,8 @@
 #include "FileInfoProvider.h"
-#include <stdexcept>
-#include <iostream>
-#include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
-#include <sstream>
-#include <regex>
 #include <string>
+#include "Utils.h"
 
 struct stat FileInfoProvider::GetPermissions(std::string fileLocation) const
 {
@@ -21,28 +17,20 @@ bool FileInfoProvider::Exists(std::string fileLocation) const
     return (stat(fileLocation.c_str(), &buf) == 0);
 }
 
-void FileInfoProvider::SetMode(std::string fileLocation, int mode) const
+bool FileInfoProvider::SetMode(std::string fileLocation, int mode) const
 {
-    cout << "setting file permissions" << "\n";
-    cout << "File is: " << fileLocation << "\n";
-    cout << "Mode is: " << mode << "\n";
-    // int status;
     // int chmod(const char *path, mode_t mode);
     // chmod((char*)"/tmp/test.txt", 100777);
     // chmod((char*)"/tmp/test.txt", S_IRWXU);
     // chmod((char*)"/tmp/test.txt", 16895);
-    chmod((char*)"/tmp/test.txt", mode);
-    chmod((char*)"/home/vagrant/TestDir/test.txt", mode);
-    // status = stat((char*)"/tmp/test.txt", &buffer);
-
+    Utils utils;
+    char * fileCharArray = utils.StringToCharArray(fileLocation);
+    return (chmod(fileCharArray, mode) == 0);
 }
 
-void FileInfoProvider::SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const
+bool FileInfoProvider::SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const
 {
-    cout << "changing ownership and group of test file" << endl;
-    cout << "uid before: " << getuid << endl;
-    cout << userID << " and group: " << groupID << endl;
-    char * tab2 = new char [fileLocation.length()+1];
-    strcpy (tab2, fileLocation.c_str());
-    chown((char*)tab2, userID, groupID);
+    Utils utils;
+    char * fileCharArray = utils.StringToCharArray(fileLocation);
+    return (chown(fileCharArray, userID, groupID) == 0);
 }

--- a/src/application/FileInfoProvider.cpp
+++ b/src/application/FileInfoProvider.cpp
@@ -2,7 +2,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <string>
-#include "Utils.h"
+#include "IUtils.h"
 
 struct stat FileInfoProvider::GetPermissions(std::string fileLocation) const
 {
@@ -19,18 +19,10 @@ bool FileInfoProvider::Exists(std::string fileLocation) const
 
 bool FileInfoProvider::SetMode(std::string fileLocation, int mode) const
 {
-    // int chmod(const char *path, mode_t mode);
-    // chmod((char*)"/tmp/test.txt", 100777);
-    // chmod((char*)"/tmp/test.txt", S_IRWXU);
-    // chmod((char*)"/tmp/test.txt", 16895);
-    Utils utils;
-    char * fileCharArray = utils.StringToCharArray(fileLocation);
-    return (chmod(fileCharArray, mode) == 0);
+    return (chmod(fileLocation.c_str(), mode) == 0);
 }
 
 bool FileInfoProvider::SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const
 {
-    Utils utils;
-    char * fileCharArray = utils.StringToCharArray(fileLocation);
-    return (chown(fileCharArray, userID, groupID) == 0);
+    return (chown(fileLocation.c_str(), userID, groupID) == 0);
 }

--- a/src/application/FileInfoProvider.cpp
+++ b/src/application/FileInfoProvider.cpp
@@ -14,3 +14,14 @@ bool FileInfoProvider::Exists(std::string fileLocation) const
     struct stat buf;
     return (stat(fileLocation.c_str(), &buf) == 0);
 }
+
+void FileInfoProvider::SetPermissions(std::string fileLocation, std::string mode) const
+{
+    cout << "setting file permissions" << "\n";
+    cout << "File is: " << fileLocation << "\n";
+    cout << "Mode is: " << mode << "\n";
+    //int chmod(const char *path, mode_t mode);
+    //int chmod(const char *fileLocation, mode_t mode);
+    //int chmod(const char *fileLocation, mode_t 0666 );
+
+}

--- a/src/application/FileInfoProvider.cpp
+++ b/src/application/FileInfoProvider.cpp
@@ -1,6 +1,9 @@
 #include "FileInfoProvider.h"
 #include <stdexcept>
 #include <iostream>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 struct stat FileInfoProvider::GetPermissions(std::string fileLocation) const
 {
@@ -15,13 +18,45 @@ bool FileInfoProvider::Exists(std::string fileLocation) const
     return (stat(fileLocation.c_str(), &buf) == 0);
 }
 
-void FileInfoProvider::SetPermissions(std::string fileLocation, std::string mode) const
+void FileInfoProvider::SetMode(std::string fileLocation, int mode) const
 {
     cout << "setting file permissions" << "\n";
     cout << "File is: " << fileLocation << "\n";
     cout << "Mode is: " << mode << "\n";
-    //int chmod(const char *path, mode_t mode);
-    //int chmod(const char *fileLocation, mode_t mode);
-    //int chmod(const char *fileLocation, mode_t 0666 );
+    int status;
+    // struct stat buffer;
+    // int chmod(const char *path, mode_t mode);
+    // chmod((char*)"/tmp/test.txt", 100777);
+    // chmod((char*)"/tmp/test.txt", S_IRWXU);
+    // chmod((char*)"/tmp/test.txt", 16895);
+    chmod((char*)"/tmp/test.txt", mode);
+    chmod((char*)"/home/vagrant/TestDir/test.txt", mode);
+    // status = stat((char*)"/tmp/test.txt", &buffer);
+    // cout << "Mode set to: " << buffer.st_mode << endl;
 
+}
+
+void FileInfoProvider::SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const
+{
+    cout << "changing ownership and group of test file" << endl;
+    cout << "uid before: " << getuid << endl;
+    //setuid(0);
+    //cout << setuid(0);
+    //cout << "uid after: " << getuid << endl;
+
+    cout << userID << " and group: " << groupID << endl;
+    //THIS IS THE BIT YOU NEED!
+    chown((char*)"/tmp/test.txt", 1234, 1234);
+    
+    // cout << "Tmp dir: " << chown((char*)"/tmp/test.txt", 1234, 1234);
+    // struct stat buf;
+    // stat((char*)"/home/vagrant/src/test.txt", &buf);
+    // cout << buf.st_gid << endl;
+    // cout << buf.st_uid << endl;
+    // cout << chown((char*)"/home/vagrant/src/test.txt", 1234, 1234) << endl;
+    // cout << 
+    // system("echo vagrant | sudo chown 1234:1234 /home/vagrant/TestDir/test.txt");
+    // stat((char*)"/home/vagrant/TestDir/test.txt", &buf);
+    // cout << buf.st_gid << endl;
+    // cout << buf.st_uid << endl;
 }

--- a/src/application/FileInfoProvider.h
+++ b/src/application/FileInfoProvider.h
@@ -12,8 +12,8 @@ class FileInfoProvider: public IFileInfoProvider
   public:
     struct stat GetPermissions(std::string fileLocation) const override;
     bool Exists(std::string fileLocation) const override;
-    void SetMode(std::string fileLocation, int mode) const override;
-    void SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const override;
+    bool SetMode(std::string fileLocation, int mode) const override;
+    bool SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const override;
 };
 
 #endif

--- a/src/application/FileInfoProvider.h
+++ b/src/application/FileInfoProvider.h
@@ -12,6 +12,7 @@ class FileInfoProvider: public IFileInfoProvider
   public:
     struct stat GetPermissions(std::string fileLocation) const override;
     bool Exists(std::string fileLocation) const override;
+    void SetPermissions(std::string fileLocation, std::string permissions) const override;
 };
 
 #endif

--- a/src/application/FileInfoProvider.h
+++ b/src/application/FileInfoProvider.h
@@ -12,7 +12,8 @@ class FileInfoProvider: public IFileInfoProvider
   public:
     struct stat GetPermissions(std::string fileLocation) const override;
     bool Exists(std::string fileLocation) const override;
-    void SetPermissions(std::string fileLocation, std::string permissions) const override;
+    void SetMode(std::string fileLocation, int mode) const override;
+    void SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const override;
 };
 
 #endif

--- a/src/application/IFileInfoProvider.h
+++ b/src/application/IFileInfoProvider.h
@@ -11,6 +11,7 @@ class IFileInfoProvider
     virtual ~IFileInfoProvider() {}
     virtual struct stat GetPermissions(std::string fileLocation) const = 0;
     virtual bool Exists(std::string fileLocation) const = 0;
+    virtual void SetPermissions(std::string fileLocation, std::string permissions) const = 0;
 };
 
 #endif

--- a/src/application/IFileInfoProvider.h
+++ b/src/application/IFileInfoProvider.h
@@ -11,8 +11,8 @@ class IFileInfoProvider
     virtual ~IFileInfoProvider() {}
     virtual struct stat GetPermissions(std::string fileLocation) const = 0;
     virtual bool Exists(std::string fileLocation) const = 0;
-    virtual void SetMode(std::string fileLocation, int mode) const = 0;
-    virtual void SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const = 0;
+    virtual bool SetMode(std::string fileLocation, int mode) const = 0;
+    virtual bool SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const = 0;
 };
 
 #endif

--- a/src/application/IFileInfoProvider.h
+++ b/src/application/IFileInfoProvider.h
@@ -11,7 +11,8 @@ class IFileInfoProvider
     virtual ~IFileInfoProvider() {}
     virtual struct stat GetPermissions(std::string fileLocation) const = 0;
     virtual bool Exists(std::string fileLocation) const = 0;
-    virtual void SetPermissions(std::string fileLocation, std::string permissions) const = 0;
+    virtual void SetMode(std::string fileLocation, int mode) const = 0;
+    virtual void SetUserAndGroupID(std::string fileLocation, int userID, int groupID) const = 0;
 };
 
 #endif

--- a/src/application/IUtils.h
+++ b/src/application/IUtils.h
@@ -1,0 +1,17 @@
+#ifndef IUtils_H
+#define IUtils_H
+
+#include <sys/stat.h>
+#include <string>
+#include <map>
+#include <vector>
+using namespace std;
+
+class IUtils
+{
+  public:
+    virtual ~IUtils() {}
+    virtual std::map<std::string, std::string> SettingsStringToMap(std::string inputSettings) const = 0;
+};
+
+#endif

--- a/src/application/Utils.cpp
+++ b/src/application/Utils.cpp
@@ -1,0 +1,43 @@
+#include <Utils.h>
+#include <regex>
+
+char* Utils::StringToCharArray(std::string input)
+{
+    char * charArray = new char [input.length()+1];
+    strcpy (charArray, input.c_str());
+    return charArray;
+}
+
+std::vector<std::string> Utils::StringSplitter(std::string permissionsStr, std::string delimiter1, std::string delimiter2)
+{
+    char delim1 = Utils::StringToCharArray(delimiter1)[0];
+    char* delim2 = Utils::StringToCharArray(delimiter2);
+    std::vector<std::string> tokens;
+    std::string token;
+    std::istringstream tokenStream(permissionsStr);
+    while (std::getline(tokenStream, token, delim1))
+    {
+        char * tab2 = new char [token.length()+1];
+        strcpy (tab2, token.c_str());
+        char * pch;
+        pch = strtok(tab2, delim2);
+        while (pch != NULL)
+        {
+            tokens.push_back(pch);
+            pch = strtok (NULL, delim2);
+        }
+    }
+    return tokens;
+}
+
+std::map<std::string, std::string> Utils::TokensToMap(std::vector<std::string> tokens)
+{
+    std::map<std::string, std::string> tokenMap;
+    for (int i = 0; i < tokens.size()-1; i++)
+    {
+
+        tokenMap[tokens[i]] = tokens[i+1];
+       i++;
+    }
+    return tokenMap;
+}

--- a/src/application/Utils.cpp
+++ b/src/application/Utils.cpp
@@ -1,43 +1,32 @@
 #include <Utils.h>
 #include <regex>
 
-char* Utils::StringToCharArray(std::string input)
+std::vector<std::string> Utils::StringSplitter(std::string permissionsStr, char delimiter) const
 {
-    char * charArray = new char [input.length()+1];
-    strcpy (charArray, input.c_str());
-    return charArray;
-}
-
-std::vector<std::string> Utils::StringSplitter(std::string permissionsStr, std::string delimiter1, std::string delimiter2)
-{
-    char delim1 = Utils::StringToCharArray(delimiter1)[0];
-    char* delim2 = Utils::StringToCharArray(delimiter2);
     std::vector<std::string> tokens;
     std::string token;
     std::istringstream tokenStream(permissionsStr);
-    while (std::getline(tokenStream, token, delim1))
+    while (std::getline(tokenStream, token, delimiter))
     {
-        char * tab2 = new char [token.length()+1];
-        strcpy (tab2, token.c_str());
-        char * pch;
-        pch = strtok(tab2, delim2);
-        while (pch != NULL)
-        {
-            tokens.push_back(pch);
-            pch = strtok (NULL, delim2);
-        }
+        tokens.push_back(token);
     }
     return tokens;
 }
 
-std::map<std::string, std::string> Utils::TokensToMap(std::vector<std::string> tokens)
+std::map<std::string, std::string> Utils::SettingsStringToMap(std::string inputSettings) const
 {
-    std::map<std::string, std::string> tokenMap;
-    for (int i = 0; i < tokens.size()-1; i++)
-    {
+    // Split on ; to get key-value pairs
+    std::vector<std::string> tokens;
+    tokens = StringSplitter(inputSettings, ';');
 
-        tokenMap[tokens[i]] = tokens[i+1];
-       i++;
+    // Loop over key-value pairs and split on =
+    std::map<std::string, std::string> tokenMap;
+    for (int i = 0; i < tokens.size(); i++)
+    {
+        std::vector<std::string> kvp;
+        kvp = StringSplitter(tokens[i], '=');
+        // put key-value pairs into map
+        tokenMap[kvp[0]] = kvp[1];
     }
     return tokenMap;
 }

--- a/src/application/Utils.h
+++ b/src/application/Utils.h
@@ -1,0 +1,15 @@
+#ifndef Utils_H
+#define Utils_H
+#include <string>
+#include <vector>
+#include <map>
+
+class Utils
+{
+  public:
+    char* StringToCharArray(std::string input);
+    std::vector<std::string> StringSplitter(std::string input, std::string delimiter1, std::string delimiter2);
+    std::map<std::string, std::string> TokensToMap(std::vector<std::string> tokens);
+};
+
+#endif

--- a/src/application/Utils.h
+++ b/src/application/Utils.h
@@ -3,13 +3,14 @@
 #include <string>
 #include <vector>
 #include <map>
+#include "IUtils.h"
 
-class Utils
+class Utils: public IUtils
 {
   public:
-    char* StringToCharArray(std::string input);
-    std::vector<std::string> StringSplitter(std::string input, std::string delimiter1, std::string delimiter2);
-    std::map<std::string, std::string> TokensToMap(std::vector<std::string> tokens);
+    std::map<std::string, std::string> SettingsStringToMap(std::string inputSettings) const override;
+  private:
+    std::vector<std::string> StringSplitter(std::string input, char delimiter) const;
 };
 
 #endif

--- a/src/application/permissionsReader.cpp
+++ b/src/application/permissionsReader.cpp
@@ -11,9 +11,9 @@ std::string PermissionsReader::GetPermissions(std::string fileLocation, IFileInf
     {
         struct stat buffer;
         struct stat buf = fileInfoProvider->GetPermissions(fileLocation);
-        std::string basicPermissions = "mode: " + std::to_string(buf.st_mode) + 
-                                    " groupID: " + std::to_string(buf.st_gid) +
-                                    " userID: " + std::to_string(buf.st_uid);
+        std::string basicPermissions = "mode=" + std::to_string(buf.st_mode) + 
+                                    ";groupID=" + std::to_string(buf.st_gid) +
+                                    ";userID=" + std::to_string(buf.st_uid);
         return basicPermissions;
     }
     else

--- a/src/application/permissionsReader.cpp
+++ b/src/application/permissionsReader.cpp
@@ -1,4 +1,4 @@
-#include "permissionsReader.h"
+#include "PermissionsReader.h"
 #include <sys/stat.h>
 #include <iostream>
 #include <stdexcept>
@@ -12,8 +12,8 @@ std::string PermissionsReader::GetPermissions(std::string fileLocation, IFileInf
         struct stat buffer;
         struct stat buf = fileInfoProvider->GetPermissions(fileLocation);
         std::string basicPermissions = "mode=" + std::to_string(buf.st_mode) + 
-                                    ";groupID=" + std::to_string(buf.st_gid) +
-                                    ";userID=" + std::to_string(buf.st_uid);
+                                    ";userID=" + std::to_string(buf.st_uid) +
+                                    ";groupID=" + std::to_string(buf.st_gid);
         return basicPermissions;
     }
     else

--- a/src/application/permissionsReader.cpp
+++ b/src/application/permissionsReader.cpp
@@ -1,6 +1,5 @@
 #include "PermissionsReader.h"
 #include <sys/stat.h>
-#include <iostream>
 #include <stdexcept>
 #include "IFileInfoProvider.h"
 

--- a/src/application/permissionsSetter.cpp
+++ b/src/application/permissionsSetter.cpp
@@ -1,37 +1,63 @@
 #include "permissionsSetter.h"
 #include <sys/stat.h>
-#include <iostream>
 #include <stdexcept>
 #include "IFileInfoProvider.h"
 #include <vector>
 #include <sstream>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <map>
 
 void PermissionsSetter::SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider) 
 {
     cout << "Attempting to change files permissions" << endl;
     if (fileInfoProvider->Exists(fileLocation))
     {   
-        std::string mode = "1000000";
+        // input string: "250 PERMISSIONS: mode: 16895 groupID: 1000 userID: 1000"
+        // const std::string prefix = "250 PERMISSIONS: ";
+        // if ( permissions.substr(0, 16) == prefix)
+        // {
+            // permissions.substr(17, permissions.size());
+        // }
+        // else
+        // {
+            // throw std::runtime_error("Failed to set permissions");
+        // }
 
-        // split permissions string
+        permissions = permissions.substr(17, permissions.size()); // Remove "250 PERMISSIONS: " prefix
+
         std::vector<std::string> tokens;
         std::string token;
         std::istringstream tokenStream(permissions);
-        while (std::getline(tokenStream, token, ', '))
+        while (std::getline(tokenStream, token, ' '))
         {
             tokens.push_back(token);
-
         }
-        std::cout << tokens.size() << std::endl;
+        // std::cout << "Number of tokens: " << tokens.size() << std::endl;
 
+        std::map<std::string, std::string> permissionsMap;
+         for (int i = 0; i < tokens.size()-1; i++)
+        {
+            std::string key = std::string(tokens[i].substr(0, tokens[i].size()-1)); // knock off the last char ":"
+            std::string val = std::string(tokens[i+1]);
+            permissionsMap[key]=val;
+            i++;
+        }
 
-        fileInfoProvider->SetPermissions(fileLocation, mode);
-    //     struct stat buffer;
-    //     struct stat buf = fileInfoProvider->GetPermissions(fileLocation);
-    //     std::string basicPermissions = "mode: " + std::to_string(buf.st_mode) + 
-    //                                 " groupID: " + std::to_string(buf.st_gid) +
-    //                                 " userID: " + std::to_string(buf.st_uid);
-    //     return basicPermissions;
+        int mode = std::stoi(permissionsMap.find("mode")->second);
+        fileInfoProvider->SetMode(fileLocation, mode);
+
+        // this is now user and groupID
+        // needs to be modified so that this is got from the user input string from
+        // SITE SETPERMISSIONS abcd
+        fileInfoProvider->SetUserAndGroupID(fileLocation, 1234, 1234);
+        // struct stat buffer;
+        // struct stat buf = fileInfoProvider->GetPermissions(fileLocation);
+        // std::string basicPermissions = "mode: " + std::to_string(buf.st_mode) + 
+                                    // " groupID: " + std::to_string(buf.st_gid) +
+                                    // " userID: " + std::to_string(buf.st_uid);
+        // return basicPermissions;
     }
     else
     {

--- a/src/application/permissionsSetter.cpp
+++ b/src/application/permissionsSetter.cpp
@@ -1,0 +1,40 @@
+#include "permissionsSetter.h"
+#include <sys/stat.h>
+#include <iostream>
+#include <stdexcept>
+#include "IFileInfoProvider.h"
+#include <vector>
+#include <sstream>
+
+void PermissionsSetter::SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider) 
+{
+    cout << "Attempting to change files permissions" << endl;
+    if (fileInfoProvider->Exists(fileLocation))
+    {   
+        std::string mode = "1000000";
+
+        // split permissions string
+        std::vector<std::string> tokens;
+        std::string token;
+        std::istringstream tokenStream(permissions);
+        while (std::getline(tokenStream, token, ', '))
+        {
+            tokens.push_back(token);
+
+        }
+        std::cout << tokens.size() << std::endl;
+
+
+        fileInfoProvider->SetPermissions(fileLocation, mode);
+    //     struct stat buffer;
+    //     struct stat buf = fileInfoProvider->GetPermissions(fileLocation);
+    //     std::string basicPermissions = "mode: " + std::to_string(buf.st_mode) + 
+    //                                 " groupID: " + std::to_string(buf.st_gid) +
+    //                                 " userID: " + std::to_string(buf.st_uid);
+    //     return basicPermissions;
+    }
+    else
+    {
+        throw std::runtime_error("Failed to set permissions");
+    }
+}

--- a/src/application/permissionsSetter.cpp
+++ b/src/application/permissionsSetter.cpp
@@ -1,60 +1,45 @@
-#include "permissionsSetter.h"
-#include <sys/stat.h>
+#include "PermissionsSetter.h"
 #include <stdexcept>
-#include "IFileInfoProvider.h"
 #include <vector>
-#include <sstream>
-#include <iostream>
-#include <string>
 #include <map>
-#include <regex>
+#include "Utils.h"
 
 void PermissionsSetter::SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider) 
 {
-    cout << "Attempting to change files permissions" << endl;
-    if (fileInfoProvider->Exists(fileLocation))
+    if (!fileInfoProvider->Exists(fileLocation))
     {   
-        cout << "Permissions: " << permissions << endl;
-
-        std::vector<std::string> tokens;
-        std::string token;
-        std::istringstream tokenStream(permissions);
-        while (std::getline(tokenStream, token, ';'))
-        {
-            char * tab2 = new char [token.length()+1];
-            strcpy (tab2, token.c_str());
-            char * pch;
-            pch = strtok(tab2, "=");
-            while (pch != NULL)
-            {
-                tokens.push_back(pch);
-                pch = strtok (NULL, "=");
-            }
-            
-
-        }
-        std::cout << "Number of tokens: " << tokens.size() << std::endl;
- 
-        std::map<std::string, int> permissionsMap;
-        for (int i = 0; i < tokens.size()-1; i++)
-        {
-            permissionsMap[tokens[i]] = atoi(tokens[i+1].c_str());
-            cout << tokens[i] << " " << tokens[i+1];
-            i++;
-        }
-
-        int mode = permissionsMap.find("mode")->second;
-        cout << "Mode value is: " << mode << endl;
-        fileInfoProvider->SetMode(fileLocation, mode);
-
-        int groupID = permissionsMap.find("groupID")->second;
-        int userID = permissionsMap.find("userID")->second;
-        cout << "File Location: " << fileLocation << endl;
-        cout << "Group: " << groupID << " User: " << userID << endl;
-        fileInfoProvider->SetUserAndGroupID(fileLocation, userID, groupID);
+        throw std::runtime_error("File not found");
     }
-    else
+    Utils utils;
+    std::vector<std::string> tokens;
+    std::map<std::string, std::string> permissionsMap;
+    int mode;
+    int groupID;
+    int userID;
+
+    try
     {
-        throw std::runtime_error("Failed to set permissions");
+        // Split the users input string and put values into a map
+        tokens = utils.StringSplitter(permissions, ";", "=");
+        permissionsMap = utils.TokensToMap(tokens);
+        mode = atoi(permissionsMap.find("mode")->second.c_str());
+        groupID = atoi(permissionsMap.find("groupID")->second.c_str());
+        userID = atoi(permissionsMap.find("userID")->second.c_str());
+    }
+    catch (std::exception& e)
+    {
+        throw std::runtime_error("Failed to read permissions");
+    }
+
+    if (fileInfoProvider->SetMode(fileLocation, mode) != 1 )
+    {
+        throw std::runtime_error("Failed to set file mode");
+    }
+    
+    if (fileInfoProvider->SetUserAndGroupID(fileLocation, userID, groupID) != 1 )
+    {
+        throw std::runtime_error("Failed to set file user and group ID");
     }
 }
+
+

--- a/src/application/permissionsSetter.cpp
+++ b/src/application/permissionsSetter.cpp
@@ -5,59 +5,53 @@
 #include <vector>
 #include <sstream>
 #include <iostream>
-#include <regex>
 #include <string>
 #include <map>
+#include <regex>
 
 void PermissionsSetter::SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider) 
 {
     cout << "Attempting to change files permissions" << endl;
     if (fileInfoProvider->Exists(fileLocation))
     {   
-        // input string: "250 PERMISSIONS: mode: 16895 groupID: 1000 userID: 1000"
-        // const std::string prefix = "250 PERMISSIONS: ";
-        // if ( permissions.substr(0, 16) == prefix)
-        // {
-            // permissions.substr(17, permissions.size());
-        // }
-        // else
-        // {
-            // throw std::runtime_error("Failed to set permissions");
-        // }
-
-        permissions = permissions.substr(17, permissions.size()); // Remove "250 PERMISSIONS: " prefix
+        cout << "Permissions: " << permissions << endl;
 
         std::vector<std::string> tokens;
         std::string token;
         std::istringstream tokenStream(permissions);
-        while (std::getline(tokenStream, token, ' '))
+        while (std::getline(tokenStream, token, ';'))
         {
-            tokens.push_back(token);
-        }
-        // std::cout << "Number of tokens: " << tokens.size() << std::endl;
+            char * tab2 = new char [token.length()+1];
+            strcpy (tab2, token.c_str());
+            char * pch;
+            pch = strtok(tab2, "=");
+            while (pch != NULL)
+            {
+                tokens.push_back(pch);
+                pch = strtok (NULL, "=");
+            }
+            
 
-        std::map<std::string, std::string> permissionsMap;
-         for (int i = 0; i < tokens.size()-1; i++)
+        }
+        std::cout << "Number of tokens: " << tokens.size() << std::endl;
+ 
+        std::map<std::string, int> permissionsMap;
+        for (int i = 0; i < tokens.size()-1; i++)
         {
-            std::string key = std::string(tokens[i].substr(0, tokens[i].size()-1)); // knock off the last char ":"
-            std::string val = std::string(tokens[i+1]);
-            permissionsMap[key]=val;
+            permissionsMap[tokens[i]] = atoi(tokens[i+1].c_str());
+            cout << tokens[i] << " " << tokens[i+1];
             i++;
         }
 
-        int mode = std::stoi(permissionsMap.find("mode")->second);
+        int mode = permissionsMap.find("mode")->second;
+        cout << "Mode value is: " << mode << endl;
         fileInfoProvider->SetMode(fileLocation, mode);
 
-        // this is now user and groupID
-        // needs to be modified so that this is got from the user input string from
-        // SITE SETPERMISSIONS abcd
-        fileInfoProvider->SetUserAndGroupID(fileLocation, 1234, 1234);
-        // struct stat buffer;
-        // struct stat buf = fileInfoProvider->GetPermissions(fileLocation);
-        // std::string basicPermissions = "mode: " + std::to_string(buf.st_mode) + 
-                                    // " groupID: " + std::to_string(buf.st_gid) +
-                                    // " userID: " + std::to_string(buf.st_uid);
-        // return basicPermissions;
+        int groupID = permissionsMap.find("groupID")->second;
+        int userID = permissionsMap.find("userID")->second;
+        cout << "File Location: " << fileLocation << endl;
+        cout << "Group: " << groupID << " User: " << userID << endl;
+        fileInfoProvider->SetUserAndGroupID(fileLocation, userID, groupID);
     }
     else
     {

--- a/src/application/permissionsSetter.cpp
+++ b/src/application/permissionsSetter.cpp
@@ -1,41 +1,35 @@
 #include "PermissionsSetter.h"
 #include <stdexcept>
-#include <vector>
 #include <map>
-#include "Utils.h"
+#include <vector>
+#include "IUtils.h"
 
-void PermissionsSetter::SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider) 
+void PermissionsSetter::SetPermissions(std::string fileLocation, std::string permissions, IUtils* utils, IFileInfoProvider* fileInfoProvider) 
 {
     if (!fileInfoProvider->Exists(fileLocation))
     {   
         throw std::runtime_error("File not found");
     }
-    Utils utils;
-    std::vector<std::string> tokens;
-    std::map<std::string, std::string> permissionsMap;
-    int mode;
-    int groupID;
-    int userID;
 
+    std::map<std::string, std::string> permissionsMap;
     try
     {
-        // Split the users input string and put values into a map
-        tokens = utils.StringSplitter(permissions, ";", "=");
-        permissionsMap = utils.TokensToMap(tokens);
-        mode = atoi(permissionsMap.find("mode")->second.c_str());
-        groupID = atoi(permissionsMap.find("groupID")->second.c_str());
-        userID = atoi(permissionsMap.find("userID")->second.c_str());
+        permissionsMap = utils->SettingsStringToMap(permissions);
     }
-    catch (std::exception& e)
+    catch(std::runtime_error const & e)
     {
-        throw std::runtime_error("Failed to read permissions");
+        throw e;
     }
+
+    int mode = stoi(permissionsMap.find("mode")->second);
+    int groupID = stoi(permissionsMap.find("groupID")->second);
+    int userID = stoi(permissionsMap.find("userID")->second);
 
     if (fileInfoProvider->SetMode(fileLocation, mode) != 1 )
     {
         throw std::runtime_error("Failed to set file mode");
     }
-    
+
     if (fileInfoProvider->SetUserAndGroupID(fileLocation, userID, groupID) != 1 )
     {
         throw std::runtime_error("Failed to set file user and group ID");

--- a/src/application/permissionsSetter.h
+++ b/src/application/permissionsSetter.h
@@ -1,13 +1,15 @@
 #ifndef PermissionsSetter_H
 #define PermissionsSetter_H
 
+#include <map>
 #include <string>
 #include "IFileInfoProvider.h"
+#include "IUtils.h"
 
 class PermissionsSetter
 {
   public:
-    void SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider);
+    void SetPermissions(std::string fileLocation, std::string permissions, IUtils* utils, IFileInfoProvider* fileInfoProvider);
 };
 
 #endif

--- a/src/application/permissionsSetter.h
+++ b/src/application/permissionsSetter.h
@@ -1,0 +1,14 @@
+#ifndef PermissionsSetter_H
+#define PermissionsSetter_H
+
+#include <string>
+#include "IFileInfoProvider.h"
+using namespace std;
+
+class PermissionsSetter
+{
+  public:
+    void SetPermissions(std::string fileLocation, std::string permissions, IFileInfoProvider* fileInfoProvider);
+};
+
+#endif

--- a/src/application/permissionsSetter.h
+++ b/src/application/permissionsSetter.h
@@ -3,7 +3,6 @@
 
 #include <string>
 #include "IFileInfoProvider.h"
-using namespace std;
 
 class PermissionsSetter
 {

--- a/src/permissions_plugin.cpp
+++ b/src/permissions_plugin.cpp
@@ -268,7 +268,7 @@ get_permissions(
 
       try
       {
-            std::string permissions = "group, user, mode";
+            std::string permissions = "mode: 16895 groupID: 1000 userID: 1000";
 
             permissionsSetter.SetPermissions(filePath, permissions, &fileInfoProvider);
 

--- a/src/permissions_plugin.cpp
+++ b/src/permissions_plugin.cpp
@@ -260,6 +260,14 @@ get_permissions(
             return;            
         }
 
+      cout << "ARGC " << argc << endl;
+      if (argc != 4)
+      {
+        result = GlobusGFSErrorGeneric("Incorrect number of arguments to SITE SETPERMISSIONS command");
+        globus_gridftp_server_finished_command(op, result, (char*)"550 Incorrect number of arguments to SITE SETPERMISSIONS command.\r\n");
+        return;          
+      }
+
       std::string filePath;
       filePath = argv[2];     
       std::string permissions;
@@ -277,7 +285,7 @@ get_permissions(
             // char *cstr = &permissionsString[0u];
             char final_output[1024];
             // snprintf(final_output, 1024, "250 PERMISSIONS: %s\r\n", cstr);
-            snprintf(final_output, 1024, "250 PERMISSIONS: test test\r\n");
+            snprintf(final_output, 1024, "250 SETPERMISSIONS: Completed successfully\r\n");
             final_output[1023] = '\0';
             globus_gridftp_server_finished_command(op, result, final_output);
         }

--- a/src/permissions_plugin.cpp
+++ b/src/permissions_plugin.cpp
@@ -7,9 +7,10 @@
 
  #include <sys/types.h>
  #include <fcntl.h>
- #include "./application/permissionsReader.h"
- #include "./application/permissionsSetter.h"
+ #include "./application/PermissionsReader.h"
+ #include "./application/PermissionsSetter.h"
  #include "./application/FileInfoProvider.h"
+ #include "./application/Utils.h"
  using namespace std;
 
 
@@ -260,7 +261,6 @@ get_permissions(
             return;            
         }
 
-      cout << "ARGC " << argc << endl;
       if (argc != 4)
       {
         result = GlobusGFSErrorGeneric("Incorrect number of arguments to SITE SETPERMISSIONS command");
@@ -275,14 +275,13 @@ get_permissions(
 
       PermissionsSetter permissionsSetter;
       FileInfoProvider fileInfoProvider;
+      Utils utils;
 
       try
       {
             //std::string permissions = "mode: 16895 groupID: 1000 userID: 1000";
-           // cout << permissions << endl;
-            permissionsSetter.SetPermissions(filePath, permissions, &fileInfoProvider);
+            permissionsSetter.SetPermissions(filePath, permissions, &utils, &fileInfoProvider);
 
-            // char *cstr = &permissionsString[0u];
             char final_output[1024];
             // snprintf(final_output, 1024, "250 PERMISSIONS: %s\r\n", cstr);
             snprintf(final_output, 1024, "250 SETPERMISSIONS: Completed successfully\r\n");

--- a/src/permissions_plugin.cpp
+++ b/src/permissions_plugin.cpp
@@ -262,14 +262,16 @@ get_permissions(
 
       std::string filePath;
       filePath = argv[2];     
+      std::string permissions;
+      permissions = argv[3];
 
       PermissionsSetter permissionsSetter;
       FileInfoProvider fileInfoProvider;
 
       try
       {
-            std::string permissions = "mode: 16895 groupID: 1000 userID: 1000";
-
+            //std::string permissions = "mode: 16895 groupID: 1000 userID: 1000";
+           // cout << permissions << endl;
             permissionsSetter.SetPermissions(filePath, permissions, &fileInfoProvider);
 
             // char *cstr = &permissionsString[0u];

--- a/src/run-gridftp-server.sh
+++ b/src/run-gridftp-server.sh
@@ -3,4 +3,4 @@ export LD_LIBRARY_PATH
 
 echo $LD_LIBRARY_PATH
 
-globus-gridftp-server -control-interface 127.0.0.1 -aa -p 5000 -dsi permissions_plugin -d ALL -debug
+sudo globus-gridftp-server -control-interface 127.0.0.1 -aa -p 5000 -dsi permissions_plugin -d ALL -debug

--- a/src/test/application/MockFileInfoProvider.h
+++ b/src/test/application/MockFileInfoProvider.h
@@ -9,6 +9,7 @@ class MockFileInfoProvider : public IFileInfoProvider {
  public:
    MOCK_CONST_METHOD1(GetPermissions, struct stat(std::string fileLocation));
    MOCK_CONST_METHOD1(Exists, bool (std::string fileLocation));
+   MOCK_CONST_METHOD2(SetPermissions, void (std::string fileLocation, std::string permissions));
 };
 
 #endif

--- a/src/test/application/MockFileInfoProvider.h
+++ b/src/test/application/MockFileInfoProvider.h
@@ -4,13 +4,14 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "../../application/IFileInfoProvider.h"
+using namespace std;
 
 class MockFileInfoProvider : public IFileInfoProvider {
  public:
    MOCK_CONST_METHOD1(GetPermissions, struct stat(std::string fileLocation));
    MOCK_CONST_METHOD1(Exists, bool (std::string fileLocation));
-  //  MOCK_CONST_METHOD2(SetMode, void (std::string fileLocation, int mode));
-  // MOCK_CONST_METHOD3(SetUserAndGroupID, void (std::string fileLocation, int userID, int groupID));
+   MOCK_CONST_METHOD2(SetMode, void (std::string fileLocation, int mode));
+   MOCK_CONST_METHOD3(SetUserAndGroupID, void (std::string fileLocation, int userID, int groupID));
 };
 
 #endif

--- a/src/test/application/MockFileInfoProvider.h
+++ b/src/test/application/MockFileInfoProvider.h
@@ -9,7 +9,8 @@ class MockFileInfoProvider : public IFileInfoProvider {
  public:
    MOCK_CONST_METHOD1(GetPermissions, struct stat(std::string fileLocation));
    MOCK_CONST_METHOD1(Exists, bool (std::string fileLocation));
-   MOCK_CONST_METHOD2(SetPermissions, void (std::string fileLocation, std::string permissions));
+  //  MOCK_CONST_METHOD2(SetMode, void (std::string fileLocation, int mode));
+  // MOCK_CONST_METHOD3(SetUserAndGroupID, void (std::string fileLocation, int userID, int groupID));
 };
 
 #endif

--- a/src/test/application/MockFileInfoProvider.h
+++ b/src/test/application/MockFileInfoProvider.h
@@ -10,8 +10,8 @@ class MockFileInfoProvider : public IFileInfoProvider {
  public:
    MOCK_CONST_METHOD1(GetPermissions, struct stat(std::string fileLocation));
    MOCK_CONST_METHOD1(Exists, bool (std::string fileLocation));
-   MOCK_CONST_METHOD2(SetMode, void (std::string fileLocation, int mode));
-   MOCK_CONST_METHOD3(SetUserAndGroupID, void (std::string fileLocation, int userID, int groupID));
+   MOCK_CONST_METHOD2(SetMode, bool (std::string fileLocation, int mode));
+   MOCK_CONST_METHOD3(SetUserAndGroupID, bool (std::string fileLocation, int userID, int groupID));
 };
 
 #endif

--- a/src/test/application/MockUtils.h
+++ b/src/test/application/MockUtils.h
@@ -1,0 +1,14 @@
+#ifndef MOCK_Utils_H
+#define MOCK_Utils_H
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "../../application/IUtils.h"
+using namespace std;
+
+class MockUtils : public IUtils {
+ public:
+   MOCK_CONST_METHOD1(SettingsStringToMap, std::map<std::string, std::string> (std::string settingsString));
+};
+
+#endif

--- a/src/test/application/PermissionsSetterTests.cpp
+++ b/src/test/application/PermissionsSetterTests.cpp
@@ -1,0 +1,35 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "MockFileInfoProvider.h"
+#include "../../application/PermissionsSetter.h"
+#include <string>
+
+using ::testing::Return;
+using ::testing::_;
+
+class PermissionsSetterTests : public ::testing::Test
+{
+    protected:
+      MockFileInfoProvider mockFileInfoProvider;
+      std::string fileName = "file123.txt";
+      PermissionsSetter permissionsSetter;
+      std::string permissionsString = "mode=100777;groupID=1234;userID=1234";
+
+      virtual void setup() {}
+    
+      virtual void TearDown() {}
+};
+
+TEST_F(PermissionsSetterTests, CheckAssertion)
+{
+    EXPECT_CALL(mockFileInfoProvider, Exists(_)).WillRepeatedly(Return(false));
+    
+    try{
+        permissionsSetter.SetPermissions(fileName, permissionsString, &mockFileInfoProvider);
+        FAIL() << "Expected: File not found error";
+    }
+    catch(std::runtime_error const & e)
+    {
+        ASSERT_EQ(e.what(), std::string("File not found"));
+    }
+}

--- a/src/test/application/PermissionsSetterTests.cpp
+++ b/src/test/application/PermissionsSetterTests.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "MockFileInfoProvider.h"
+#include "MockUtils.h"
 #include "../../application/PermissionsSetter.h"
 #include <string>
 
@@ -11,25 +12,55 @@ class PermissionsSetterTests : public ::testing::Test
 {
     protected:
       MockFileInfoProvider mockFileInfoProvider;
+      MockUtils mockUtils;
       std::string fileName = "file123.txt";
       PermissionsSetter permissionsSetter;
       std::string permissionsString = "mode=100777;groupID=1234;userID=1234";
+      std::vector<std::string> tokens;
+      std::map<std::string, std::string> permissionsMap;
 
-      virtual void setup() {}
+      virtual void setup() {
+          tokens = {"mode", "10077", "userID", "1000", "groupID", "1000"};
+          permissionsMap = {{"mode", "100777"}, {"userID", "1000"}, {"groupID", "1000"}};
+      }
     
       virtual void TearDown() {}
 };
 
-TEST_F(PermissionsSetterTests, CheckAssertion)
+ACTION(ThrowException)
 {
+    throw std::runtime_error("Test exception thrown");
+}
+
+TEST_F(PermissionsSetterTests, ThrowRuntimeErrorIfFileDoesntExist)
+{
+    setup();
     EXPECT_CALL(mockFileInfoProvider, Exists(_)).WillRepeatedly(Return(false));
+    EXPECT_CALL(mockUtils, SettingsStringToMap(permissionsString)).WillRepeatedly(Return(permissionsMap));
     
     try{
-        permissionsSetter.SetPermissions(fileName, permissionsString, &mockFileInfoProvider);
+        permissionsSetter.SetPermissions(fileName, permissionsString, &mockUtils, &mockFileInfoProvider);
         FAIL() << "Expected: File not found error";
     }
     catch(std::runtime_error const & e)
     {
         ASSERT_EQ(e.what(), std::string("File not found"));
     }
+}
+
+TEST_F(PermissionsSetterTests, ThrowRuntimeErrorIfModeNotSet)
+{
+    setup();
+    EXPECT_CALL(mockFileInfoProvider, Exists(_)).WillRepeatedly(Return(true));
+    EXPECT_CALL(mockUtils, SettingsStringToMap(permissionsString)).WillRepeatedly(Return(permissionsMap));
+    EXPECT_CALL(mockFileInfoProvider, SetMode(_, 100777)).WillRepeatedly(Return(false));
+
+    try{
+        permissionsSetter.SetPermissions(fileName, permissionsString, &mockUtils, &mockFileInfoProvider);
+        FAIL() << "Expected: Failed to set file mode";
+    }
+    catch(std::runtime_error const & e)
+    {
+        ASSERT_EQ(e.what(), std::string("Failed to set file mode"));
+    }   
 }

--- a/src/test/application/UtilsTests.cpp
+++ b/src/test/application/UtilsTests.cpp
@@ -1,0 +1,28 @@
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "MockFileInfoProvider.h"
+#include "../../application/Utils.h"
+#include <string>
+
+using ::testing::Return;
+using ::testing::_;
+
+class UtilsTests : public ::testing::Test
+{
+    protected:
+      Utils utils;
+      std::string settingsString = "mode=100777;userID=1234;groupID=12345";
+
+      virtual void setup() {
+      }
+    
+      virtual void TearDown() {}
+};
+
+TEST_F(UtilsTests, CheckSettingsStringToMapReturnsCorrectNumberOfMapEntries)
+{
+    std::map<std::string, std::string> permissionsMap = utils.SettingsStringToMap(settingsString);
+    ASSERT_EQ(stoi(permissionsMap.find("mode")->second), 100777);
+    ASSERT_EQ(stoi(permissionsMap.find("userID")->second), 1234);
+    ASSERT_EQ(stoi(permissionsMap.find("groupID")->second), 12345);
+}

--- a/src/test/application/permissionsReaderTests.cpp
+++ b/src/test/application/permissionsReaderTests.cpp
@@ -35,7 +35,7 @@ TEST_F(PermissionsReaderTests, CheckAssertion)
     PermissionsReader permissionsReader;
     ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode: 32768 groupID: 1000 userID: 1000");
 
-    buf.st_mode = S_IFDIR;  // directory, 16384 equiv 400000 octal, must update mock each time st_mode is changed 
+    buf.st_mode = S_IFDIR;  // directory, 16384 equiv 40000 octal, must update mock each time st_mode is changed 
     EXPECT_CALL(mockFileInfoProvider, GetPermissions("file123.txt")).WillRepeatedly(Return(buf));
     ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode: 16384 groupID: 1000 userID: 1000");
 

--- a/src/test/application/permissionsReaderTests.cpp
+++ b/src/test/application/permissionsReaderTests.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 #include "gmock/gmock.h"
 #include "MockFileInfoProvider.h"
-#include "../../application/permissionsReader.h"
+#include "../../application/PermissionsReader.h"
 #include <string>
 
 using ::testing::Return;
@@ -9,40 +9,49 @@ using ::testing::_;
 
 class PermissionsReaderTests : public ::testing::Test
 {
-    std::string fileName = "file123.txt";
-    // MockFileInfoProvider mockFileInfoProvider;
+    protected:
+      std::string fileName = "file123.txt";
+      MockFileInfoProvider mockFileInfoProvider;
+      PermissionsReader permissionsReader;
+      struct stat buf;
 
-    virtual void setup() {}
-
+    virtual void setup() {
+        buf.st_mode = S_IFREG;  // file octal value
+        buf.st_gid = 1000;
+        buf.st_uid = 1000;
+    }
     virtual void TearDown() {}
 };
 
-TEST_F(PermissionsReaderTests, CheckAssertion)
+TEST_F(PermissionsReaderTests, CheckOutputPermissionsStringForFile)
 {
-    MockFileInfoProvider mockFileInfoProvider;
-
-    std::string fileName = "file123.txt";
-
-    // add attribute st_mode
-    struct stat buf;
-    buf.st_mode = S_IFREG;  // file octal value
-    buf.st_gid = 1000;
-    buf.st_uid = 1000;
-
-    // Update mock object with attribute
+    PermissionsReaderTests::setup();
     EXPECT_CALL(mockFileInfoProvider, GetPermissions("file123.txt")).WillRepeatedly(Return(buf));
     EXPECT_CALL(mockFileInfoProvider, Exists("file123.txt")).WillRepeatedly(Return(1));
-    PermissionsReader permissionsReader;
-    ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode: 32768 groupID: 1000 userID: 1000");
+    ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode=32768;userID=1000;groupID=1000");
+}
 
-    buf.st_mode = S_IFDIR;  // directory, 16384 equiv 40000 octal, must update mock each time st_mode is changed 
+TEST_F(PermissionsReaderTests, CheckOutputPermissionsStringForDirectory)
+{
+    PermissionsReaderTests::setup();
+    buf.st_mode = S_IFDIR;  // directory, 16384 equiv 40000 octal, must update mock each time st_mode is changed
     EXPECT_CALL(mockFileInfoProvider, GetPermissions("file123.txt")).WillRepeatedly(Return(buf));
-    ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode: 16384 groupID: 1000 userID: 1000");
+    EXPECT_CALL(mockFileInfoProvider, Exists("file123.txt")).WillRepeatedly(Return(1));
+    ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode=16384;userID=1000;groupID=1000");
+}
 
-    buf.st_mode = S_IFLNK; // link
+TEST_F(PermissionsReaderTests, CheckOutputPermissionsStringForLink)
+{
+    PermissionsReaderTests::setup();
+    buf.st_mode = S_IFLNK;
     EXPECT_CALL(mockFileInfoProvider, GetPermissions("file123.txt")).WillRepeatedly(Return(buf));
-    ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode: 40960 groupID: 1000 userID: 1000");
+    EXPECT_CALL(mockFileInfoProvider, Exists("file123.txt")).WillRepeatedly(Return(1));
+    ASSERT_EQ(permissionsReader.GetPermissions(fileName, &mockFileInfoProvider), "mode=40960;userID=1000;groupID=1000");
+}
 
+TEST_F(PermissionsReaderTests, ThrowsRuntimeErrorWhenFileDoesntExist)
+{
+    PermissionsReaderTests::setup();
     EXPECT_CALL(mockFileInfoProvider, Exists("file123.txt")).WillRepeatedly(Return(0));
     try {
         permissionsReader.GetPermissions(fileName, &mockFileInfoProvider);

--- a/src/test/application/permissionsReaderTests.cpp
+++ b/src/test/application/permissionsReaderTests.cpp
@@ -10,7 +10,7 @@ using ::testing::_;
 class PermissionsReaderTests : public ::testing::Test
 {
     std::string fileName = "file123.txt";
-    MockFileInfoProvider mockFileInfoProvider;
+    // MockFileInfoProvider mockFileInfoProvider;
 
     virtual void setup() {}
 


### PR DESCRIPTION
Permissions string was reformatted for consistency (mode, user, then group) and delimiters changed to ease splitting

PermissionsReader tests were split up (based on previous comments), to ease bug checking. Tests were written in the same style for PermissionsSetting

A utilities class was added for Permissions Setting

